### PR TITLE
Autoquad_interface changed to utilize mavros_msgs/Mavlink instead of …

### DIFF
--- a/autoquad_interface/CMakeLists.txt
+++ b/autoquad_interface/CMakeLists.txt
@@ -9,15 +9,23 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   message_generation
+  mavros_msgs
 )
 
 #SET(
 #  CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake
 #)
 
+#INCLUDE_DIRECTORIES(
+#  ${CMAKE_SOURCE_DIR}/autoquad_ros/include/mavlink/v1.0/
+#  ${CMAKE_SOURCE_DIR}/autoquad_ros/include/mavlink/v1.0/common/
+#)
+
 INCLUDE_DIRECTORIES(
-  ${CMAKE_SOURCE_DIR}/autoquad_ros/include/mavlink/v1.0/
-  ${CMAKE_SOURCE_DIR}/autoquad_ros/include/mavlink/v1.0/common/
+  ${CMAKE_SOURCE_DIR}/AQ-MAVROS/autoquad_interface/include/mavlink/v1.0/
+  ${CMAKE_SOURCE_DIR}/AQ-MAVROS/autoquad_interface/include/mavlink/v1.0/common/
+  #${CMAKE_SOURCE_DIR}/autoquad_interface/include/mavlink/v1.0/
+  #${CMAKE_SOURCE_DIR}/autoquad_interface/include/mavlink/v1.0/common/
 )
 
 
@@ -97,11 +105,11 @@ INCLUDE_DIRECTORIES(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES mavlink
-#  CATKIN_DEPENDS roscpp rospy std_msgs
-#  DEPENDS system_lib
-#   message_runtime
+  INCLUDE_DIRS include
+  LIBRARIES mavlink
+  CATKIN_DEPENDS roscpp rospy std_msgs
+  DEPENDS system_lib
+   message_runtime
 )
 
 ###########
@@ -113,6 +121,7 @@ catkin_package(
 # include_directories(include)
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  include
 #  ${GLIB2_MAIN_INCLUDE_DIR}
 #  ${GLIB2_INTERNAL_INCLUDE_DIR}
 )

--- a/autoquad_interface/package.xml
+++ b/autoquad_interface/package.xml
@@ -43,11 +43,13 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>mavros_msgs</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>mavros_msgs</run_depend>
   <build_depend>message_generation</build_depend>
   <run_depend>message_runtime</run_depend>
 


### PR DESCRIPTION
…it's own implementation of Mavlink messages - fromlcm is outcommented in the node. Fixed includes in CMakeLists.txt file. Updated package to depend on mavros_msgs.